### PR TITLE
fix: do not check invalid node_modules folder.

### DIFF
--- a/src/findByKeyword.ts
+++ b/src/findByKeyword.ts
@@ -1,8 +1,7 @@
-import fs from 'fs';
 import path from 'path';
 import { unpartial } from 'unpartial';
-import find from 'find'
-import Bluebird from 'bluebird'
+import { findPackagesInfo } from './findPackagesInfo';
+import { readFileSafe } from './readFileSafe';
 
 export type FindOptions = {
   cwd: string
@@ -20,62 +19,4 @@ export async function findByKeyword(keyword: string, options: Partial<FindOption
     if (!pjson.keywords) return false
     return pjson.keywords.indexOf(keyword) !== -1
   }).map(pkg => pkg.name)
-}
-
-async function findPackagesInfo(cwd: string): Promise<{ name: string, path: string }[]> {
-  let baseDirs = await new Promise<string[]>(a => {
-    if (!fs.existsSync(cwd)) {
-      a([])
-      return
-    }
-    find.dir('node_modules', cwd, dirs => {
-      a(dirs.map(d => path.join(d, '..')))
-    })
-  })
-
-  return Bluebird.reduce(baseDirs, async (packages: { name: string, path: string }[], baseDir) => {
-    const nodeModulesPath = path.resolve(baseDir, 'node_modules')
-    const dirs = await readDirSafe(nodeModulesPath)
-    await Promise.all(dirs.map(async dir => {
-      if (!dir.startsWith('@'))
-        packages.push({ name: dir, path: path.join(nodeModulesPath, dir) })
-      else if (dir !== '@types') {
-        const foldersInScopedDir = await readDirSafe(path.resolve(nodeModulesPath, dir))
-        packages.push(...foldersInScopedDir.map(d => ({ name: `${dir}/${d}`, path: path.join(nodeModulesPath, dir, d) })))
-      }
-    }))
-    return packages
-  }, [])
-}
-
-function readDirSafe(path: string) {
-  return new Promise<string[]>((a, r) => {
-    fs.readdir(path, (err, dirs) => {
-      // istanbul ignore next
-      if (err && err.code !== 'ENOENT')
-        r(err)
-      else
-        a(dirs)
-    })
-  })
-}
-
-
-/**
- * Read file and ignore ENOENT.
- * When the the folder is a link, the link may be invalid.
- * That will result in ENOENT.
- * @param path file path.
- */
-function readFileSafe(path: string) {
-  try {
-    return fs.readFileSync(path, 'utf8')
-  }
-  catch (err) {
-    // istanbul ignore next
-    if (err.code === 'ENOENT')
-      return undefined
-    // istanbul ignore next
-    throw err
-  }
 }

--- a/src/findPackagesInfo.spec.ts
+++ b/src/findPackagesInfo.spec.ts
@@ -1,0 +1,8 @@
+import { findPackagesInfo } from './findPackagesInfo';
+import a from 'assertron'
+test('node_modules in test folder will not take into consideration', async () => {
+  const packagesInfo = await findPackagesInfo('fixtures/node_modules-in-test')
+
+  a.satisfies(packagesInfo, [{ name: 'pkg-with-test' }])
+  expect(packagesInfo.length).toBe(1)
+})

--- a/src/findPackagesInfo.ts
+++ b/src/findPackagesInfo.ts
@@ -1,0 +1,50 @@
+import Bluebird from 'bluebird';
+import find from 'find';
+import fs from 'fs';
+import path from 'path';
+
+export async function findPackagesInfo(cwd: string): Promise<{ name: string, path: string }[]> {
+  let baseDirs = await new Promise<string[]>(a => {
+    if (!fs.existsSync(cwd)) {
+      a([])
+      return
+    }
+    find.dir('node_modules', cwd, dirs => {
+      a(dirs.filter(isPackagePath).map(d => path.join(d, '..')))
+    })
+  })
+
+  return Bluebird.reduce(baseDirs, async (packages: { name: string, path: string }[], baseDir) => {
+    const nodeModulesPath = path.resolve(baseDir, 'node_modules')
+    const dirs = await readDirSafe(nodeModulesPath)
+    await Promise.all(dirs.map(async dir => {
+      if (!dir.startsWith('@'))
+        packages.push({ name: dir, path: path.join(nodeModulesPath, dir) })
+      else if (dir !== '@types') {
+        const foldersInScopedDir = await readDirSafe(path.resolve(nodeModulesPath, dir))
+        packages.push(...foldersInScopedDir.map(d => ({ name: `${dir}/${d}`, path: path.join(nodeModulesPath, dir, d) })))
+      }
+    }))
+    return packages
+  }, [])
+}
+
+function readDirSafe(path: string) {
+  return new Promise<string[]>((a, r) => {
+    fs.readdir(path, (err, dirs) => {
+      // istanbul ignore next
+      if (err && err.code !== 'ENOENT')
+        r(err)
+      else
+        a(dirs)
+    })
+  })
+}
+
+
+function isPackagePath(dir: string) {
+  const matches = /node_modules\/(.*)\/node_modules/.exec(dir)
+  if (!matches) return true
+
+  return /\@.*\/.*/.test(matches[1]) || /^[^\/]+$/.test(matches[1])
+}

--- a/src/readFileSafe.ts
+++ b/src/readFileSafe.ts
@@ -1,0 +1,20 @@
+import fs from 'fs'
+
+/**
+ * Read file and ignore ENOENT.
+ * When the the folder is a link, the link may be invalid.
+ * That will result in ENOENT.
+ * @param path file path.
+ */
+export function readFileSafe(path: string) {
+  try {
+    return fs.readFileSync(path, 'utf8')
+  }
+  catch (err) {
+    // istanbul ignore next
+    if (err.code === 'ENOENT')
+      return undefined
+    // istanbul ignore next
+    throw err
+  }
+}


### PR DESCRIPTION
There are packages (`resolve`) that distribute its test code in the package.

https://github.com/browserify/resolve/issues/171

And in those test code it can contain the folder `node_modules` which messed up the calculation.
