### PR TITLE
fix: exclude non top level node_modules in search

### DIFF
--- a/src/findByKeyword.spec.ts
+++ b/src/findByKeyword.spec.ts
@@ -40,4 +40,10 @@ describe('find local', () => {
     const actual = await findByKeyword('some-keyword', { cwd: 'fixtures/at-types-plugin' })
     expect(actual).toEqual([])
   })
+
+  test('should not get package not under top node_modules hierarchy', async () => {
+    const packagesInfo = await findByKeyword('some-keyword')
+
+    expect(packagesInfo).toEqual([])
+  })
 })

--- a/src/findByKeyword.ts
+++ b/src/findByKeyword.ts
@@ -7,12 +7,11 @@ export type FindOptions = {
   cwd: string
 }
 
-export async function findByKeyword(keyword: string, options: Partial<FindOptions>) {
+export async function findByKeyword(keyword: string, options?: Partial<FindOptions>) {
   const { cwd } = unpartial({ cwd: '.' }, options)
 
   const pkgInfos = await findPackagesInfo(cwd)
   return pkgInfos.filter(pkg => {
-
     const content = readFileSafe(path.resolve(cwd, pkg.path, 'package.json'))
     if (!content) return false
     const pjson = JSON.parse(content)

--- a/src/findPackagesInfo.ts
+++ b/src/findPackagesInfo.ts
@@ -10,7 +10,7 @@ export async function findPackagesInfo(cwd: string): Promise<{ name: string, pat
       return
     }
     find.dir('node_modules', cwd, dirs => {
-      a(dirs.filter(isPackagePath).map(d => path.join(d, '..')))
+      a(dirs.filter(dir => isPackagePath(cwd, dir)).map(d => path.join(d, '..')))
     })
   })
 
@@ -42,7 +42,9 @@ function readDirSafe(path: string) {
 }
 
 
-function isPackagePath(dir: string) {
+function isPackagePath(cwd: string, dir: string) {
+  if (!path.relative(cwd, dir).startsWith('node_modules')) return false
+
   const matches = /node_modules\/(.*)\/node_modules/.exec(dir)
   if (!matches) return true
 


### PR DESCRIPTION
This avoid loading "packages" in unexpected places such as "fixtures"

fix: make options optional