### PR TITLE
fix: skip files in node_modules

### DIFF
--- a/src/findByKeyword.spec.ts
+++ b/src/findByKeyword.spec.ts
@@ -46,4 +46,9 @@ describe('find local', () => {
 
     expect(packagesInfo).toEqual([])
   })
+
+  test('ignore files under node_modules', async () => {
+    const packagesInfo = await findByKeyword('some', { cwd: 'fixtures/node_modules-with-file' })
+    expect(packagesInfo.length).toBe(0)
+  })
 })

--- a/src/findPackagesInfo.spec.ts
+++ b/src/findPackagesInfo.spec.ts
@@ -1,5 +1,6 @@
+import a from 'assertron';
 import { findPackagesInfo } from './findPackagesInfo';
-import a from 'assertron'
+
 test('node_modules in test folder will not take into consideration', async () => {
   const packagesInfo = await findPackagesInfo('fixtures/node_modules-in-test')
 

--- a/src/findPackagesInfo.ts
+++ b/src/findPackagesInfo.ts
@@ -18,11 +18,13 @@ export async function findPackagesInfo(cwd: string): Promise<{ name: string, pat
     const nodeModulesPath = path.resolve(baseDir, 'node_modules')
     const dirs = await readDirSafe(nodeModulesPath)
     await Promise.all(dirs.map(async dir => {
-      if (!dir.startsWith('@'))
-        packages.push({ name: dir, path: path.join(nodeModulesPath, dir) })
-      else if (dir !== '@types') {
-        const foldersInScopedDir = await readDirSafe(path.resolve(nodeModulesPath, dir))
-        packages.push(...foldersInScopedDir.map(d => ({ name: `${dir}/${d}`, path: path.join(nodeModulesPath, dir, d) })))
+      if (fs.statSync(path.join(nodeModulesPath, dir)).isDirectory()) {
+        if (!dir.startsWith('@'))
+          packages.push({ name: dir, path: path.join(nodeModulesPath, dir) })
+        else if (dir !== '@types') {
+          const foldersInScopedDir = await readDirSafe(path.resolve(nodeModulesPath, dir))
+          packages.push(...foldersInScopedDir.map(d => ({ name: `${dir}/${d}`, path: path.join(nodeModulesPath, dir, d) })))
+        }
       }
     }))
     return packages
@@ -40,7 +42,6 @@ function readDirSafe(path: string) {
     })
   })
 }
-
 
 function isPackagePath(cwd: string, dir: string) {
   if (!path.relative(cwd, dir).startsWith('node_modules')) return false


### PR DESCRIPTION
yarn adds a .yarn-integrity in node_modules.